### PR TITLE
w_try_7z: Fixup

### DIFF
--- a/src/winetricks
+++ b/src/winetricks
@@ -716,7 +716,11 @@ w_try_7z()
         w_try_cd "${PWD}"
 
         # errors out if there is a space between -o and path
-        w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -y -o"$(w_pathconv -w "${destdir}")" "$@"
+        if [ "${W_ARCH}" = "win64" ]; then
+            w_try "${WINE}" "${W_PROGRAMS_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -y -o"$(w_pathconv -w "${destdir}")" "$@"
+        elif [ "${W_ARCH}" = "win32" ]; then
+            w_try "${WINE}" "${W_PROGRAMS_X86_WIN}\\7-Zip\\7z.exe" x "$(w_pathconv -w "${filename}")" -y -o"$(w_pathconv -w "${destdir}")" "$@"
+        fi
     fi
 }
 


### PR DESCRIPTION
Currently `w_try_7z` is broken in a 64-bit prefix due together verb changes, this fixes the function.